### PR TITLE
Use install command for installing sublime theme

### DIFF
--- a/contrib/sublime/Makefile
+++ b/contrib/sublime/Makefile
@@ -1,15 +1,15 @@
 THEME        := VICE.tmTheme
 SCRIPT       := maketheme.php
-INSTALL_DEST := "$(HOME)/.config/sublime-text-3/Packages/Color Scheme - Default/${THEME}"
+INSTALL_DEST := "$(HOME)/.config/sublime-text-3/Packages/Color Scheme - Default/$(THEME)"
 
-${THEME}: ${SCRIPT}
+$(THEME): $(SCRIPT)
 	php $< > $@
 
-install: ${THEME}
-	cp ${THEME} ${INSTALL_DEST}
+install: $(THEME)
+	install -Dm644 $(THEME) $(INSTALL_DEST)
 
 debug:
-	ls ${SCRIPT} | entr -s "make install"
+	ls $(SCRIPT) | entr -s "make install"
 
 clean:
-	rm -f ${THEME}
+	rm -f $(THEME)


### PR DESCRIPTION
The current install target for a vanilla install of Sublime 3 that doesn't have any packages installed fails:
```
➜ make install
cp VICE.tmTheme "/home/tlambiris/.config/sublime-text-3/Packages/Color Scheme - Default/VICE.tmTheme"
cp: cannot create regular file '/home/tlambiris/.config/sublime-text-3/Packages/Color Scheme - Default/VICE.tmTheme': No such file or directory
make: *** [Makefile:9: install] Error 1
zsh: exit 2     make install
```

This fixes it was well as normalizing the other variables (should be referenced as `$(VARIABLE)`):
```
➜ make install
install -Dm644 VICE.tmTheme "/home/tlambiris/.config/sublime-text-3/Packages/Color Scheme - Default/VICE.tmTheme"

➜ ls -la "/home/tlambiris/.config/sublime-text-3/Packages/Color Scheme - Default/VICE.tmTheme"
-rw-r--r-- 1 tlambiris users 11K Mar  4 21:17 '/home/tlambiris/.config/sublime-text-3/Packages/Color Scheme - Default/VICE.tmTheme'
```

Next thing I'll be working on as porting the theme to binary.ninja.

Thanks again!